### PR TITLE
Fix test_container_persistence_and_recovery: relation already exists error (vibe-kanban)

### DIFF
--- a/tests/deployment_tests.rs
+++ b/tests/deployment_tests.rs
@@ -520,6 +520,9 @@ async fn test_container_persistence_and_recovery() -> Result<()> {
 
     client.execute("CREATE SCHEMA IF NOT EXISTS persistence_test", &[]).await?;
     
+    // Drop table if it exists to ensure clean state from previous test runs
+    client.execute("DROP TABLE IF EXISTS persistence_test.recovery_data", &[]).await?;
+    
     client.execute("
         CREATE TABLE persistence_test.recovery_data (
             id SERIAL PRIMARY KEY,


### PR DESCRIPTION
The test `test_container_persistence_and_recovery` fails with error: "relation 'recovery_data' already exists". This happens because the test creates a table without checking if it already exists from previous test runs. The test should either:
1. Use `CREATE TABLE IF NOT EXISTS` instead of `CREATE TABLE`
2. Drop the schema/table before creating it
3. Use a unique schema name per test run

Location: `tests/deployment_tests.rs:470`