### PR TITLE
Temporary disable CI (vibe-kanban)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,10 +1,15 @@
 name: Integration Tests
 
+# TEMPORARILY DISABLED - Re-enable after code preparation
+# TODO: Re-enable CI workflow triggers
+# on:
+#   push:
+#     branches: [ main, develop ]
+#   pull_request:
+#     branches: [ main, develop ]
+
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_dispatch:  # Only allow manual runs for now
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Disable GitHub CI for now temporarly. Issue a fixing issue to ensure re-enable after code preparation.